### PR TITLE
Support passing environment variables to mcp servers spawned with StdioClientTransport

### DIFF
--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -278,6 +278,7 @@ export class MCPClient {
         this.transport = new StdioClientTransport({
           command,
           args,
+          env: { ...process.env } as Record<string, string>,
         });
         this.mcp.connect(this.transport);
         serverWithoutCommand = args.join(" ");
@@ -291,6 +292,7 @@ export class MCPClient {
         this.transport = new StdioClientTransport({
           command,
           args,
+          env: { ...process.env } as Record<string, string>,
         });
         this.mcp.connect(this.transport);
         serverWithoutCommand = args.join(" ");
@@ -304,6 +306,7 @@ export class MCPClient {
         this.transport = new StdioClientTransport({
           command,
           args,
+          env: { ...process.env } as Record<string, string>,
         });
         this.mcp.connect(this.transport);
         serverWithoutCommand = args.join(" ");
@@ -338,6 +341,7 @@ export class MCPClient {
         this.transport = new StdioClientTransport({
           command,
           args,
+          env: { ...process.env } as Record<string, string>,
         });
         this.mcp.connect(this.transport);
       }


### PR DESCRIPTION

See this in typescript SDK: https://github.com/modelcontextprotocol/typescript-sdk/blob/1878143f1a8ffc3ce5f7acd4dc61cef67b589b4b/src/client/stdio.ts#L66

Found while looking into this issue: https://github.com/Flux159/mcp-server-kubernetes/issues/148

I think better alternative is going to be passing cli argument to mcp-server-kubernetes so that `npx mcp-chat --server "npx mcp-server-kubernetes --kubeconfig=PATH"` will actually work. Right now the env var approach will fail for any client that doesn't passthrough env vars.

Summary:

Test Plan:
